### PR TITLE
indexes must start with ix_ or ixu_

### DIFF
--- a/src/sonar-sql-plugin/src/main/java/org/antlr/sql/dialects/rules/TSQLRules.java
+++ b/src/sonar-sql-plugin/src/main/java/org/antlr/sql/dialects/rules/TSQLRules.java
@@ -273,6 +273,7 @@ public enum TSQLRules {
 		main.getNames().getTextItem().add(IdContext.class.getSimpleName());
 		main.setTextCheckType(TextCheckType.CONTAINS);
 		main.getTextToFind().getTextItem().add("IX_");
+		main.getTextToFind().getTextItem().add("IXU_");
 		main.setRuleMatchType(RuleMatchType.TEXT_AND_CLASS);
 		main.setRuleResultType(RuleResultType.FAIL_IF_NOT_FOUND);
 


### PR DESCRIPTION
Our naming convention uses ix_ for indexes and ixu_ for unique indexes. This change allows both prefixes.